### PR TITLE
Enable mobile navigation

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -32,6 +32,11 @@ body {
 .container {
   width: 80%; }
 
+@media (max-width: 600px) {
+  .container {
+    width: 95%; }
+}
+
 nav {
   background-color: #4B9CD3;
   height: 80px;

--- a/static/styles.css
+++ b/static/styles.css
@@ -31,6 +31,11 @@ body {
   
   .container {
   width: 80%; }
+
+  @media (max-width: 600px) {
+    .container {
+    width: 95%; }
+  }
   
   nav {
   background-color: #4B9CD3;

--- a/views/data_entry.html
+++ b/views/data_entry.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin Dashboard - Data Entry</title>
   <!-- Materialize CSS and JS for styling -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
@@ -15,6 +16,7 @@
     <nav>
       <div class="nav-wrapper">
         <a href="/" class="brand-logo left">Timetable</a>
+        <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
         <ul class="right hide-on-med-and-down">
           <li><a href="/dashboard">Dashboard</a></li>
           <li><a href="/logout">Logout</a></li>
@@ -22,6 +24,11 @@
         </ul>
       </div>
     </nav>
+    <ul class="sidenav" id="mobile-demo">
+      <li><a href="/dashboard">Dashboard</a></li>
+      <li><a href="/logout">Logout</a></li>
+      <li><a href="/select_timeslot">Select Timeslots</a></li>
+    </ul>
   </header>
 
   <main class="container">
@@ -91,5 +98,11 @@
   </footer>
 
   <script src="/static/script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('.sidenav');
+      M.Sidenav.init(elems);
+    });
+  </script>
 </body>
 </html>

--- a/views/get_role_number.html
+++ b/views/get_role_number.html
@@ -113,6 +113,10 @@
                     </ul>
                 </div>
             </nav>
+            <ul class="sidenav" id="mobile-demo">
+                <li><a href="/dashboard">Dashboard</a></li>
+                <li><a href="/logout">Logout</a></li>
+            </ul>
         </header>
         <div class="container"></div>
         <h4 class="header">Weekly Timetable</h4>
@@ -146,9 +150,15 @@
         document.getElementById('get-data').onclick = function() {
             window.location.href = '/get_admin_data';
         };
-        document.getElementById('send-schedule').onclick = function() {
-            window.location.href = '/get_role_no';
-        };
+    document.getElementById('send-schedule').onclick = function() {
+        window.location.href = '/get_role_no';
+    };
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var elems = document.querySelectorAll('.sidenav');
+            M.Sidenav.init(elems);
+        });
     </script>
 </body>
 </html>

--- a/views/home.html
+++ b/views/home.html
@@ -131,6 +131,7 @@
     <nav>
         <div class="nav-wrapper">
             <a href="/" class="brand-logo left">Timetable</a>
+            <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
             <ul class="right hide-on-med-and-down">
                 <li><a href="/dashboard">Dashboard</a></li>
                 <li><a href="/logout">Logout</a></li>
@@ -138,6 +139,11 @@
             </ul>
         </div>
     </nav>
+    <ul class="sidenav" id="mobile-demo">
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/logout">Logout</a></li>
+        <li><a href="/select_timeslot">Select Timeslots</a></li>
+    </ul>
 
     <!-- Welcome Section -->
     <div class="welcome-section">
@@ -172,6 +178,12 @@
 
     <!-- Materialize JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var elems = document.querySelectorAll('.sidenav');
+            M.Sidenav.init(elems);
+        });
+    </script>
 </body>
 
 </html>

--- a/views/prof_busy_slot_selection.html
+++ b/views/prof_busy_slot_selection.html
@@ -75,6 +75,7 @@
     <nav>
         <div class="nav-wrapper">
             <a href="/" class="brand-logo left">Timetable</a>
+            <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
             <ul class="right hide-on-med-and-down">
                 <li><a href="/dashboard">Dashboard</a></li>
                 <li><a href="/logout">Logout</a></li>
@@ -82,6 +83,11 @@
             </ul>
         </div>
     </nav>
+    <ul class="sidenav" id="mobile-demo">
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/logout">Logout</a></li>
+        <li><a href="/select_timeslot">Select Timeslots</a></li>
+    </ul>
 
     <div class="container">
         <h1 class="center-align">Professor Slot Selection</h1>
@@ -119,5 +125,11 @@
 
     <!-- Materialize JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var elems = document.querySelectorAll('.sidenav');
+            M.Sidenav.init(elems);
+        });
+    </script>
 </body>
 </html>

--- a/views/select_timeslots.html
+++ b/views/select_timeslots.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Timeslot Picker</title>
     <!-- Material Design Lite CSS -->
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
@@ -177,6 +178,7 @@
     <nav>
         <div class="nav-wrapper">
             <a href="/" class="brand-logo left">Timetable</a>
+            <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
             <ul class="right hide-on-med-and-down">
                 <li><a href="/dashboard">Dashboard</a></li>
                 <li><a href="/logout">Logout</a></li>
@@ -184,6 +186,11 @@
             </ul>
         </div>
     </nav>
+    <ul class="sidenav" id="mobile-demo">
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/logout">Logout</a></li>
+        <li><a href="/select_timeslot">Select Timeslots</a></li>
+    </ul>
 <h1>Timeslot Picker</h1>
 
 <div id="timeslots"></div>
@@ -412,6 +419,12 @@ submitBtn.onclick = function () {
     // Initialize with one empty timeslot
     timeslotsContainer.appendChild(createTimeslot());
     updateMoveButtons();
+</script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var elems = document.querySelectorAll('.sidenav');
+        M.Sidenav.init(elems);
+    });
 </script>
 
 </body>

--- a/views/student_timetable.html
+++ b/views/student_timetable.html
@@ -91,6 +91,10 @@
                 </ul>
             </div>
         </nav>
+        <ul class="sidenav" id="mobile-demo">
+            <li><a href="/dashboard">Dashboard</a></li>
+            <li><a href="/logout">Logout</a></li>
+        </ul>
     </header>
 
     <main>
@@ -128,6 +132,12 @@
         document.getElementById('download-csv').onclick = function() {
             window.location.href = '/download-timetable/{roll_number}';
         };
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var elems = document.querySelectorAll('.sidenav');
+            M.Sidenav.init(elems);
+        });
     </script>
 </body>
 </html>

--- a/views/timetable.html
+++ b/views/timetable.html
@@ -149,6 +149,10 @@
                 </ul>
             </div>
         </nav>
+        <ul class="sidenav" id="mobile-demo">
+            <li><a href="/dashboard">Dashboard</a></li>
+            <li><a href="/logout">Logout</a></li>
+        </ul>
     </header>
 
     <main>
@@ -304,9 +308,15 @@
         document.getElementById('get-data').onclick = function() {
             window.location.href = '/get_admin_data';
         };
-        document.getElementById('send-schedule').onclick = function() {
-            window.location.href = '/get_role_no';
-        };
+    document.getElementById('send-schedule').onclick = function() {
+        window.location.href = '/get_role_no';
+    };
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var elems = document.querySelectorAll('.sidenav');
+            M.Sidenav.init(elems);
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve `.container` styles for mobile
- add mobile navigation menus with Materialize side nav
- initialize side nav on page load
- include viewport meta tag on missing templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685274285f688320b9fd234ef680019c